### PR TITLE
Update authors and add to docs sidebar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Calculate Cook County Property Tax Bills and Simulate Scenarios
 Version: 0.6.1
 Authors@R: c(
     person(given = "Dan", family = "Snow", email = "daniel.snow@cookcountyil.gov", role = c("aut", "cre")),
-    person(given = "Mike", family = "Wu", role = c("aut", "ctb")),
-    person(given = "Rob", family = "Ross", role = c("aut", "ctb"))
+    person(given = "Rob", family = "Ross", role = c("aut", "ctb")),
+    person(given = "Mike", family = "Wu", role = c("ctb"))
     )
 Description: An R package to estimate property tax bills and simulate tax
     scenarios for Cook County, IL. Supplementary to a SQLite database file

--- a/README.md
+++ b/README.md
@@ -863,15 +863,15 @@ erDiagram
 
 - Currently, the per-district tax calculations for properties in the
   Red-Purple Modernization (RPM) TIF are slightly flawed. However, the
-  total tax bill per PIN is still accurate. See issue [\#11](#11) for
+  total tax bill per PIN is still accurate. See issue [\#4](https://github.com/ccao-data/ptaxsim/issues/4) for
   more information.
 - Special Service Area (SSA) rates must be calculated manually when
-  creating counterfactual bills. See issue [\#31](#31) for more
+  creating counterfactual bills. See issue [\#3](https://github.com/ccao-data/ptaxsim/issues/3) for more
   information.
 - In rare instances, a TIF can have multiple `agency_num` identifiers
   (usually there’s only one per TIF). The `tif_crosswalk` table
   determines what the “main” `agency_num` is for each TIF and pulls the
-  name and TIF information using that identifier. See issue [\#39](#39)
+  name and TIF information using that identifier. See archived issue [\#39](https://gitlab.com/ccao-data-science---modeling/packages/ptaxsim/-/issues/39)
   for more information.
 - PTAXSIM is relatively memory-efficient and can calculate every
   district line-item for every tax bill for the last 15 years (roughly

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,12 @@
 destination: public
 url: https://github.com/ccao-data/ptaxsim
 
+authors:
+  sidebar:
+    roles: [aut, ctb]
+  Dan Snow:
+    href: https://github.com/dfsnow
+
 reference:
 
 - title: Functions

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,6 +6,8 @@ authors:
     roles: [aut, ctb]
   Dan Snow:
     href: https://github.com/dfsnow
+  Rob Ross:
+    href: https://github.com/rross0
 
 reference:
 


### PR DESCRIPTION
This PR updates the PTAXSIM authors order and adds details for each author to the documentation page sidebar.