### PR TITLE
Disable indentation_linter introduced in lintr 3.1.0

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: linters_with_defaults(
     object_name_linter = NULL,
     object_length_linter = NULL,
-    object_usage_linter = NULL
+    object_usage_linter = NULL,
+    indentation_linter = NULL
   )
 encoding: "UTF-8"


### PR DESCRIPTION
The rules followed by indentation_linter aren't consistent with those from styler, so one or the other will throw an error unless one is disabled.