### PR TITLE
Move PTAXSIM DB file to runner temp dir

### DIFF
--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -27,8 +27,8 @@ runs:
         PDIR=$RUNNER_TEMP
         echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_ENV
         echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_OUTPUT
-        if [[ "$RUNNER_OS" =~ ^(Linux|macOS)$ ]] && mkdir -p $PDIR
-        if [[ "$RUNNER_OS" == "Windows" ]] && mkdir $PDIR
+        if [[ "$RUNNER_OS" =~ ^(Linux|macOS)$ ]]; then mkdir -p $PDIR; fi
+        if [[ "$RUNNER_OS" == "Windows" ]]; then mkdir $PDIR; fi
       shell: bash
 
     - name: Get database version

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -55,7 +55,8 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2 --quiet
+        cd ${{ env.PTAXSIM_DB_DIR }}
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ptaxsim.db.bz2 --quiet
       shell: bash
 
     - name: Unpack database (Linux)

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -8,6 +8,9 @@ inputs:
   ASSUMED_ROLE:
     description: AWS role used for S3 actions
 outputs:
+  PTAXSIM_DB_PATH:
+    description: "PTAXSIM database path on runner"
+    value: ${{ steps.set_db_path.outputs.PTAXSIM_DB_PATH }}
   PTAXSIM_VERSION:
     description: "PTAXSIM database version"
     value: ${{ steps.version_db.outputs.PTAXSIM_VERSION }}
@@ -18,11 +21,17 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set database path
+      id: set_db_path
+      run: |
+        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Get database version
       id: version_db
       run: |
         DESCRIPTION_PATH=$(echo "${{ github.workspace }}/DESCRIPTION" | sed 's/\\/\//g')
-        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=$(sed -n 's/.*Wants_DB_Version: \([0-9]*\.[0-9]*\.[0-9]\).*/\1/p' $DESCRIPTION_PATH)" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=${{ env.PTAXSIM_VERSION }}" >> $GITHUB_OUTPUT
       shell: bash
@@ -31,7 +40,7 @@ runs:
       uses: actions/cache@v3.3.2
       id: cache_db
       with:
-        path: $RUNNER_TEMP/ptaxsim.db.bz2
+        path: ${{ env.PTAXSIM_DB_PATH}}/ptaxsim.db.bz2
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
@@ -46,25 +55,25 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 $RUNNER_TEMP/ptaxsim.db.bz2 --quiet
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2 --quiet
       shell: bash
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk $RUNNER_TEMP/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk $RUNNER_TEMP/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x $RUNNER_TEMP\ptaxsim.db.bz2
+        7z x ${{ env.PTAXSIM_DB_PATH }}\ptaxsim.db.bz2
       shell: cmd

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -24,8 +24,11 @@ runs:
     - name: Set database directory
       id: set_db_dir
       run: |
-        echo "PTAXSIM_DB_DIR=$RUNNER_TEMP" >> $GITHUB_ENV
-        echo "PTAXSIM_DB_DIR=$RUNNER_TEMP" >> $GITHUB_OUTPUT
+        PDIR=$RUNNER_TEMP
+        echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_OUTPUT
+        if [[ "$RUNNER_OS" =~ ^(Linux|macOS)$ ]] && mkdir -p $PDIR
+        if [[ "$RUNNER_OS" == "Windows" ]] && mkdir $PDIR
       shell: bash
 
     - name: Get database version
@@ -55,26 +58,29 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        cd ${{ env.PTAXSIM_DB_DIR }}
         aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ptaxsim.db.bz2 --quiet
       shell: bash
+      working-directory: ${{ env.PTAXSIM_DB_DIR }}
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2
+        pbzip2 -dk ptaxsim.db.bz2
       shell: bash
+      working-directory: ${{ env.PTAXSIM_DB_DIR }}
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2
+        pbzip2 -dk ptaxsim.db.bz2
       shell: bash
+      working-directory: ${{ env.PTAXSIM_DB_DIR }}
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x ${{ env.PTAXSIM_DB_DIR }}\ptaxsim.db.bz2
+        7z x ptaxsim.db.bz2
       shell: cmd
+      working-directory: ${{ env.PTAXSIM_DB_DIR }}

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -22,7 +22,7 @@ runs:
       id: version_db
       run: |
         DESCRIPTION_PATH=$(echo "${{ github.workspace }}/DESCRIPTION" | sed 's/\\/\//g')
-        echo "PTAXSIM_DB_PATH=${{ env.RUNNER_TEMP }}" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=$(sed -n 's/.*Wants_DB_Version: \([0-9]*\.[0-9]*\.[0-9]\).*/\1/p' $DESCRIPTION_PATH)" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=${{ env.PTAXSIM_VERSION }}" >> $GITHUB_OUTPUT
       shell: bash
@@ -31,7 +31,7 @@ runs:
       uses: actions/cache@v3.3.2
       id: cache_db
       with:
-        path: ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
+        path: $RUNNER_TEMP/ptaxsim.db.bz2
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
@@ -46,25 +46,25 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2 --quiet
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 $RUNNER_TEMP/ptaxsim.db.bz2 --quiet
       shell: bash
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
+        pbzip2 -dk $RUNNER_TEMP/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
+        pbzip2 -dk $RUNNER_TEMP/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x ${{ env.RUNNER_TEMP }}\ptaxsim.db.bz2
+        7z x $RUNNER_TEMP\ptaxsim.db.bz2
       shell: cmd

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -22,6 +22,7 @@ runs:
       id: version_db
       run: |
         DESCRIPTION_PATH=$(echo "${{ github.workspace }}/DESCRIPTION" | sed 's/\\/\//g')
+        echo "PTAXSIM_DB_PATH=${{ env.RUNNER_TEMP }}" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=$(sed -n 's/.*Wants_DB_Version: \([0-9]*\.[0-9]*\.[0-9]\).*/\1/p' $DESCRIPTION_PATH)" >> $GITHUB_ENV
         echo "PTAXSIM_VERSION=${{ env.PTAXSIM_VERSION }}" >> $GITHUB_OUTPUT
       shell: bash
@@ -30,7 +31,7 @@ runs:
       uses: actions/cache@v3.3.2
       id: cache_db
       with:
-        path: ptaxsim.db.bz2
+        path: ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
@@ -45,25 +46,25 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ptaxsim.db.bz2 --quiet
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2 --quiet
       shell: bash
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk ${{ github.workspace }}/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk ${{ github.workspace }}/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.RUNNER_TEMP }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x ${{ github.workspace }}\ptaxsim.db.bz2
+        7z x ${{ env.RUNNER_TEMP }}\ptaxsim.db.bz2
       shell: cmd

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -8,9 +8,9 @@ inputs:
   ASSUMED_ROLE:
     description: AWS role used for S3 actions
 outputs:
-  PTAXSIM_DB_PATH:
-    description: "PTAXSIM database path on runner"
-    value: ${{ steps.set_db_path.outputs.PTAXSIM_DB_PATH }}
+  PTAXSIM_DB_DIR:
+    description: "PTAXSIM database directory on runner"
+    value: ${{ steps.set_db_dir.outputs.PTAXSIM_DB_DIR }}
   PTAXSIM_VERSION:
     description: "PTAXSIM database version"
     value: ${{ steps.version_db.outputs.PTAXSIM_VERSION }}
@@ -21,12 +21,11 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set database path
-      id: set_db_path
+    - name: Set database directory
+      id: set_db_dir
       run: |
-        echo "PTAXSIM_DB_PATH_COMP=$RUNNER_TEMP/ptaxsim.db.bz2" >> $GITHUB_ENV
-        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP/ptaxsim.db" >> $GITHUB_ENV
-        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP/ptaxsim.db" >> $GITHUB_OUTPUT
+        echo "PTAXSIM_DB_DIR=$RUNNER_TEMP" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_DIR=$RUNNER_TEMP" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get database version
@@ -41,7 +40,7 @@ runs:
       uses: actions/cache@v3.3.2
       id: cache_db
       with:
-        path: ${{ env.PTAXSIM_DB_PATH_COMP }}
+        path: ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
@@ -56,25 +55,25 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_PATH_COMP }} --quiet
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2 --quiet
       shell: bash
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH_COMP }}
+        pbzip2 -dk ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH_COMP }}
+        pbzip2 -dk ${{ env.PTAXSIM_DB_DIR }}/ptaxsim.db.bz2
       shell: bash
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x ${{ env.PTAXSIM_DB_PATH_COMP }}
+        7z x ${{ env.PTAXSIM_DB_DIR }}\ptaxsim.db.bz2
       shell: cmd

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -24,8 +24,9 @@ runs:
     - name: Set database path
       id: set_db_path
       run: |
-        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_ENV
-        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP" >> $GITHUB_OUTPUT
+        echo "PTAXSIM_DB_PATH_COMP=$RUNNER_TEMP/ptaxsim.db.bz2" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP/ptaxsim.db" >> $GITHUB_ENV
+        echo "PTAXSIM_DB_PATH=$RUNNER_TEMP/ptaxsim.db" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get database version
@@ -40,7 +41,7 @@ runs:
       uses: actions/cache@v3.3.2
       id: cache_db
       with:
-        path: ${{ env.PTAXSIM_DB_PATH}}/ptaxsim.db.bz2
+        path: ${{ env.PTAXSIM_DB_PATH_COMP }}
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
@@ -55,25 +56,25 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2 --quiet
+        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ${{ env.PTAXSIM_DB_PATH_COMP }} --quiet
       shell: bash
 
     - name: Unpack database (Linux)
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH_COMP }}
       shell: bash
 
     - name: Unpack database (macOS)
       if: runner.os == 'macOS'
       run: |
         brew install pbzip2
-        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH }}/ptaxsim.db.bz2
+        pbzip2 -dk ${{ env.PTAXSIM_DB_PATH_COMP }}
       shell: bash
 
     - name: Unpack database (Windows)
       if: runner.os == 'Windows'
       run: |
-        7z x ${{ env.PTAXSIM_DB_PATH }}\ptaxsim.db.bz2
+        7z x ${{ env.PTAXSIM_DB_PATH_COMP }}
       shell: cmd

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -27,8 +27,6 @@ runs:
         PDIR=$RUNNER_TEMP
         echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_ENV
         echo "PTAXSIM_DB_DIR=$PDIR" >> $GITHUB_OUTPUT
-        if [[ "$RUNNER_OS" =~ ^(Linux|macOS)$ ]]; then mkdir -p $PDIR; fi
-        if [[ "$RUNNER_OS" == "Windows" ]]; then mkdir $PDIR; fi
       shell: bash
 
     - name: Get database version

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,6 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
     env:
-      PTAXSIM_DB_PATH: ${{ github.workspace }}/ptaxsim.db
       R_KEEP_PKG_SOURCE: yes
 
     # Required for OIDC access to S3
@@ -48,9 +47,14 @@ jobs:
           needs: check
 
       - name: Prepare PTAXSIM database
+        id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
         with:
           ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+
+      - name: Set PTAXSIM database path
+        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV
+        shell: bash
 
       - name: Check R package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -35,9 +35,14 @@ jobs:
           needs: website
 
       - name: Prepare PTAXSIM database
+        id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
         with:
           ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+
+      - name: Set PTAXSIM database path
+        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_PATH }}" >> $GITHUB_ENV
+        shell: bash
 
       - name: Build pkgdown site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -10,8 +10,6 @@ name: pkgdown
 jobs:
   build-pkgdown-site:
     runs-on: ubuntu-latest
-    env:
-      PTAXSIM_DB_PATH: ${{ github.workspace }}/ptaxsim.db
 
     # Required for OIDC access to S3
     permissions:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,7 @@ jobs:
           ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Set PTAXSIM database path
-        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_PATH }}" >> $GITHUB_ENV
+        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV
         shell: bash
 
       - name: Build pkgdown site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Set PTAXSIM database path
-        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_PATH }}" >> $GITHUB_ENV
+        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV
         shell: bash
 
       - name: Test coverage

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,8 +8,6 @@ name: test-coverage
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
-    env:
-      PTAXSIM_DB_PATH: ${{ github.workspace }}/ptaxsim.db
 
     # Required for OIDC access to S3
     permissions:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -30,9 +30,14 @@ jobs:
           needs: coverage
 
       - name: Prepare PTAXSIM database
+        id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
         with:
           ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
+
+      - name: Set PTAXSIM database path
+        run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_PATH }}" >> $GITHUB_ENV
+        shell: bash
 
       - name: Test coverage
         run: |

--- a/R/tax_bill.R
+++ b/R/tax_bill.R
@@ -194,6 +194,7 @@ tax_bill <- function(year_vec,
   # Calculate the exemption effect by subtracting the exempt amount from
   # the total taxable EAV
   dt[, agency_tax_rate := agency_total_ext / as.numeric(agency_total_eav)]
+  dt[, agency_tax_rate := replace(agency_tax_rate, is.nan(agency_tax_rate), 0)]
   dt[, tax_amt_exe := exe_total * agency_tax_rate]
   dt[, tax_amt_pre_exe := round(eav * agency_tax_rate, 2)]
   dt[, tax_amt_post_exe := round(tax_amt_pre_exe - tax_amt_exe, 2)]

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -244,4 +244,10 @@ test_that("agnostic to input data.table row order", {
   )
 })
 
+test_that("Returns 0 for agency with base/levy of 0", {
+  expect_false(
+    any(is.nan(tax_bill(2022, c("12283000140000", "12284120030000"))$final_tax))
+  )
+})
+
 DBI::dbDisconnect(ptaxsim_db_conn)

--- a/vignettes/appeals.Rmd
+++ b/vignettes/appeals.Rmd
@@ -50,6 +50,14 @@ library(sf)
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 ```
 
+```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
+```
+
 ## Gathering PINs of interest
 
 To determine the impact of appeals, we first need a way to gather all the properties (PINs) in Schaumburg. Fortunately, PTAXSIM's database has all the data required to accomplish this task.
@@ -228,7 +236,7 @@ sb_pins_summ <- sb_pins_all %>%
     ),
     idx = (med_av / med_av[stage == "2018\nboard"]) * 100
   )
-```  
+```
 
 Finally, we can plot the index over time to see how reassessment and the subsequent appeals at each stage impacted assessed values.
 

--- a/vignettes/exemptions.Rmd
+++ b/vignettes/exemptions.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-Property tax exemptions are savings that lower a homeowner’s property tax bill. They work by reducing or freezing the taxable value (Equalized Assessed Value, or EAV) of a home. For example, the most common exemption, the Homeowner Exemption, reduces EAV by \$10,000. 
+Property tax exemptions are savings that lower a homeowner’s property tax bill. They work by reducing or freezing the taxable value (Equalized Assessed Value, or EAV) of a home. For example, the most common exemption, the Homeowner Exemption, reduces EAV by \$10,000.
 
 Once the exemption EAV has been subtracted from the property's EAV, the final EAV is multiplied by the local tax rate to get the final property tax bill. Since local tax rates can vary significantly by area, the actual effective value of each exemption likewise varies geographically.
 
@@ -39,6 +39,14 @@ library(ggplot2)
 library(ptaxsim)
 
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
+```
+
+```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
 ```
 
 The PIN we'll use is **25-32-114-005-0000**, the same PIN whose bill is shown above. This is a small, single-family property in Calumet with a very typical exemption situation, just a Homeowner Exemption.
@@ -183,7 +191,7 @@ The exemption amount for this PIN has increased in tandem with increases in the 
 
 We can also use PTAXSIM to answer hypotheticals. For example, how would this PIN's bill history change if the Homeowner Exemption increased from \$10,000 to \$15,000 in 2018?
 
-To find out, we again create a modified PIN input to pass to `tax_bill()`. This time, we increase the Homeowner Exemption to $15,000 for all years after 2018. 
+To find out, we again create a modified PIN input to pass to `tax_bill()`. This time, we increase the Homeowner Exemption to $15,000 for all years after 2018.
 
 ```{r}
 exe_dt_2 <- lookup_pin(2006:2020, "25321140050000") %>%
@@ -293,7 +301,7 @@ We're using `data.table` syntax here because it's much faster than `dplyr` when 
 t_bills_w_exe <- tax_bill(t_years, t_pins)[, stage := "With exemptions"]
 ```
 
-Unlike a single PIN, removing exemptions from many PINs means that the base (the amount of total taxable value available) will change substantially. In order to accurately model the effect of removing exemptions, we need to fully recalculate the base of each district by adding the sum of taxable value recovered from each PIN. 
+Unlike a single PIN, removing exemptions from many PINs means that the base (the amount of total taxable value available) will change substantially. In order to accurately model the effect of removing exemptions, we need to fully recalculate the base of each district by adding the sum of taxable value recovered from each PIN.
 
 To start, we use the `lookup_pin()` function to recover the total EAV of exemptions for each PIN.
 
@@ -367,7 +375,7 @@ t_no_exe_summ <- rbind(t_bills_w_exe, t_bills_no_exe)[
 ]
 ```
 
-Finally, we can plot the average bill with and without exemptions by property type. 
+Finally, we can plot the average bill with and without exemptions by property type.
 
 <details>
 
@@ -427,7 +435,7 @@ Exemptions in Calumet have significantly increased in both volume and amount (vi
 
 Conversely, Calumet's commercial property owners have picked up an increasingly large share of the overall tax burden since 2006. In 2019, the average commercial property paid about $1,100 more than they would have if exemptions did not exist.
 
-## Changing exemptions 
+## Changing exemptions
 
 PTAXSIM can also answer hypotheticals about large areas. For example, how would the average residential tax bill in Calumet change if the Senior Exemption increased by $5,000 and the Senior Freeze Exemption was removed?
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -49,6 +49,14 @@ library(ptaxsim)
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("ptaxsim.db"))
   ```
 
+  ```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
+  ```
+
 ## The main function - `tax_bill()` {#main-arguments}
 
 PTAXSIM has a single primary function - `tax_bill()` - with two *required* arguments:

--- a/vignettes/mapping.Rmd
+++ b/vignettes/mapping.Rmd
@@ -41,6 +41,14 @@ library(tidyr)
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 ```
 
+```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
+```
+
 ## Single taxing district
 
 We're going to use the the Village of Ford Heights as our example taxing district, since it's relatively small and uncomplicated.
@@ -362,7 +370,7 @@ fhm_pins <- DBI::dbGetQuery(
 )
 ```
 
-This gives us about 2,300 PINs, roughly 300 more than the Village of Ford Heights has alone. We can fetch and prepare the geometries the same way we did for the single district case. 
+This gives us about 2,300 PINs, roughly 300 more than the Village of Ford Heights has alone. We can fetch and prepare the geometries the same way we did for the single district case.
 
 ```{r}
 fhm_pins_geo <- lookup_pin10_geometry(

--- a/vignettes/reassessment.Rmd
+++ b/vignettes/reassessment.Rmd
@@ -46,7 +46,15 @@ library(tidyr)
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 ```
 
-The example PIN we’ll use is **16-26-406-015-0000**. This is a small, single-family property in West Chicago without any exemptions. We can use the `tax_bill()` function to get every bill for this PIN from 2006 to 2021. 
+```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
+```
+
+The example PIN we’ll use is **16-26-406-015-0000**. This is a small, single-family property in West Chicago without any exemptions. We can use the `tax_bill()` function to get every bill for this PIN from 2006 to 2021.
 
 ```{r}
 p <- tax_bill(2006:2021, "16264060150000")
@@ -744,7 +752,7 @@ cw_fut_agency_tots <- DBI::dbGetQuery(
 
 ## Levies
 
-We also need to recalculate levies for the whole county based on our assumption: 
+We also need to recalculate levies for the whole county based on our assumption:
 
 - All levies will change by their average change of the last 3 years
 
@@ -768,7 +776,7 @@ cw_fut_levies <- lookup_agency(
 
 ## Preparing inputs
 
-Now that we've calculated our hypothetical future values, we need to transform the data into the format excepted by `tax_bill()`. We do this by replicating the input format provided by each `lookup_` function from PTAXSIM. 
+Now that we've calculated our hypothetical future values, we need to transform the data into the format excepted by `tax_bill()`. We do this by replicating the input format provided by each `lookup_` function from PTAXSIM.
 
 ```{r}
 # Prep pin_dt. Keep only Ward 22 pins

--- a/vignettes/tifs.Rmd
+++ b/vignettes/tifs.Rmd
@@ -41,6 +41,14 @@ library(sf)
 ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 ```
 
+```{r, echo=FALSE}
+# This is needed to build the vignette using GitHub Actions
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
+```
+
 ## Gathering PINs of interest
 
 To determine the TIF's impact, we first need a way to gather all the properties (PINs) in Wheeling. Fortunately, PTAXSIM's database has all the data required to accomplish this task.
@@ -188,7 +196,7 @@ wh_pins_map
 
 The map shows the TIF district highlighted in <span style="color:#7d26cd"><strong>purple</strong></span>. It covers mostly commercial buildings and a small park. The primary development is called the [Wheeling Town Center](https://thewheelingtowncenter.com/).
 
-### A quick aside: tax codes 
+### A quick aside: tax codes
 
 The Wheeling Town Center II TIF was created by layering an additional taxing district boundary onto existing districts. When this happened, a new ***tax code*** was created. A tax code is a 5-digit number that identifies the unique combination of overlapping tax districts for a given area.
 


### PR DESCRIPTION
This PR fixes two bugs related to our PTAXSIM CI integration. Mainly:

- Newer versions of R seem to copy the contents of the package directory to a temporary folder when building a package. Usually this is fine, but GitHub runners only have a limited amount of disk space. The unzipped PTAXSIM DB file was being copied from the working directory to the temp build directory, exhausting the disk space on the runner. To fix this, I moved to the PTAXSIM DB file to the temp directory and pointed all connection strings to the new location.
- One of the tests pulls a random selection of 1M PINs and compared the PTAXSIM-calculated tax bill to the real tax bill. This test was [intermittently failing](https://github.com/ccao-data/ptaxsim/actions/runs/8944108955/job/24570310257). The failure turned out to be due to a single agency/base combo that resulted in a `NaN` tax rate (divide by 0 error). I added a line to replace `NaN` values with 0 and added a test to catch future issues of the same nature.