### PR TITLE
Fix file permissions error in `style-files` pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,27 +12,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-
-      - name: Install pre-commit
-        run: python -m pip install pre-commit
-        shell: bash
-
-      - name: Freeze dependencies
-        run: python -m pip freeze --local
-        shell: bash
-
-      - name: Cache pre-commit environment
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pre-commit
-            ~/.cache/R
-          key: pre-commit-3-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Run pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
-        shell: bash
+      - name: Run pre-commit checks
+        uses: ccao-data/actions/pre-commit@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9013
+    rev: v0.4.2
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
+        require_serial: true
     -   id: use-tidy-description
     -   id: lintr
     -   id: readme-rmd-rendered


### PR DESCRIPTION
This PR implements the same change as https://github.com/ccao-data/model-res-avm/pull/244 in order to fix the same bug in the `pre-commit` workflow. See that PR for more background on this change.

In addition, we switch over to the https://github.com/ccao-data/actions repo for the `pre-commit` workflow, to bring this repo in line with our other repos that use pre-commit like `model-res-avm`.

I didn't test timing for serial execution vs parallel execution in the same way that I did in https://github.com/ccao-data/model-res-avm/pull/244 and https://github.com/ccao-data/model-condo-avm/pull/49 since the results of those two PRs have me convinced that serial execution is likely better and at least no worse.