### PR TITLE
Fix appeals vignette EAV aggregation method

### DIFF
--- a/vignettes/appeals.Rmd
+++ b/vignettes/appeals.Rmd
@@ -363,8 +363,10 @@ sb_bills_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
     left_join(eq_dt_stage, by = "year") %>%
     # Aggregate the total differences for each district
     group_by(agency_num, agency_name) %>%
-    mutate(eav_diff_total = sum(eav_diff_total),
-           exe_diff_total = sum(exe_diff_total)) %>%
+    mutate(
+      eav_diff_total = sum(eav_diff_total),
+      exe_diff_total = sum(exe_diff_total)
+    ) %>%
     ungroup() %>%
     mutate(
       # Recalculate the base in terms of the "tentative" or "final" equalizer
@@ -534,7 +536,8 @@ sb_cntr_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
       mutate(
         eav_diff = (stage_av - av) * stage_eq_factor,
         exe_total = rowSums(across(starts_with("exe_"))),
-        exe_diff = (exe_total * stage_eq_factor) -(exe_total * eq_factor_final),
+        exe_diff = (exe_total * stage_eq_factor) -
+          (exe_total * eq_factor_final),
         tax_code = lookup_tax_code(2019, pin)
       ),
     sb_pin_dt_actual %>%
@@ -563,8 +566,10 @@ sb_cntr_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
     left_join(sb_pin_diff, by = c("year", "tax_code")) %>%
     left_join(eq_dt_stage, by = "year") %>%
     group_by(agency_num, agency_name) %>%
-    mutate(eav_diff_total = sum(eav_diff_total),
-           exe_diff_total = sum(exe_diff_total)) %>%
+    mutate(
+      eav_diff_total = sum(eav_diff_total),
+      exe_diff_total = sum(exe_diff_total)
+    ) %>%
     ungroup() %>%
     mutate(
       agency_total_eav = round(

--- a/vignettes/appeals.Rmd
+++ b/vignettes/appeals.Rmd
@@ -483,7 +483,7 @@ sb_bills_plot <- bind_rows(
 sb_bills_plot
 ```
 
-Overall, post-reassessment appeals in Schaumburg resulted in a roughly 11% increase in the median residential tax bill and a +20% decrease in the median commercial tax bill. Without appeals, particularly at the Board of Review, the median commercial bill would have increased roughly 30% from 2018.
+Overall, post-reassessment appeals in Schaumburg resulted in a roughly 11% increase in the median residential tax bill and a 17% decrease in the median commercial tax bill. Without appeals, particularly at the Board of Review, the median commercial bill would have increased roughly 27% from 2018.
 
 # Counterfactual scenario
 

--- a/vignettes/appeals.Rmd
+++ b/vignettes/appeals.Rmd
@@ -52,10 +52,10 @@ ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 
 ```{r, echo=FALSE}
 # This is needed to build the vignette using GitHub Actions
-#ptaxsim_db_conn <- DBI::dbConnect(
- # RSQLite::SQLite(),
-  #Sys.getenv("PTAXSIM_DB_PATH")
-#)
+ptaxsim_db_conn <- DBI::dbConnect(
+  RSQLite::SQLite(),
+  Sys.getenv("PTAXSIM_DB_PATH")
+)
 ```
 
 ## Gathering PINs of interest
@@ -481,7 +481,7 @@ sb_bills_plot <- bind_rows(
 sb_bills_plot
 ```
 
-Overall, post-reassessment appeals in Schaumburg resulted in a roughly 7% increase in the median residential tax bill and a +20% decrease in the median commercial tax bill. Without appeals, particularly at the Board of Review, the median commercial bill would have increased roughly 30% from 2018.
+Overall, post-reassessment appeals in Schaumburg resulted in a roughly 11% increase in the median residential tax bill and a +20% decrease in the median commercial tax bill. Without appeals, particularly at the Board of Review, the median commercial bill would have increased roughly 30% from 2018.
 
 # Counterfactual scenario
 
@@ -753,7 +753,7 @@ sb_cntr_plot <- bind_rows(
 sb_cntr_plot
 ```
 
-Holding commercial appeals constant makes their effect on residential tax bills clearer: large commercial appeals shift the property tax burden back to residential property owners. In the case of Schaumburg, the drop in commercial AVs during the second level of review (at the Board of Review) contributed to a roughly 7% rise in the median residential tax bill.
+Holding commercial appeals constant makes their effect on residential tax bills clearer: large commercial appeals shift the property tax burden back to residential property owners. In the case of Schaumburg, the drop in commercial AVs during the second level of review (at the Board of Review) contributed to a roughly 11% rise in the median residential tax bill.
 
 Whether or not this is correct is mostly a matter of interpretation. If the Assessor's commercial values are accurate, then the subsequent appeals unjustly shifted tax burden back to residential properties. If the Board of Review's post-appeal values are accurate, then their appeals rightly reversed the unjust increase in commercial tax bills resulting from the 2019 reassessment.
 

--- a/vignettes/appeals.Rmd
+++ b/vignettes/appeals.Rmd
@@ -52,10 +52,10 @@ ptaxsim_db_conn <- DBI::dbConnect(RSQLite::SQLite(), here("./ptaxsim.db"))
 
 ```{r, echo=FALSE}
 # This is needed to build the vignette using GitHub Actions
-ptaxsim_db_conn <- DBI::dbConnect(
-  RSQLite::SQLite(),
-  Sys.getenv("PTAXSIM_DB_PATH")
-)
+#ptaxsim_db_conn <- DBI::dbConnect(
+ # RSQLite::SQLite(),
+  #Sys.getenv("PTAXSIM_DB_PATH")
+#)
 ```
 
 ## Gathering PINs of interest
@@ -361,6 +361,11 @@ sb_bills_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
   sb_agency_dt <- lookup_agency(sb_pin_diff$year, sb_pin_diff$tax_code) %>%
     left_join(sb_pin_diff, by = c("year", "tax_code")) %>%
     left_join(eq_dt_stage, by = "year") %>%
+    # Aggregate the total differences for each district
+    group_by(agency_num, agency_name) %>%
+    mutate(eav_diff_total = sum(eav_diff_total),
+           exe_diff_total = sum(exe_diff_total)) %>%
+    ungroup() %>%
     mutate(
       # Recalculate the base in terms of the "tentative" or "final" equalizer
       agency_total_eav = round(
@@ -373,6 +378,7 @@ sb_bills_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
       -eav_diff_total, -exe_diff_total,
       -eq_factor_final, -stage_eq_factor
     ) %>%
+    as.data.table() %>%
     setkey(year, tax_code, agency_num)
 
   tax_bill(
@@ -528,8 +534,7 @@ sb_cntr_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
       mutate(
         eav_diff = (stage_av - av) * stage_eq_factor,
         exe_total = rowSums(across(starts_with("exe_"))),
-        exe_diff = (exe_total * stage_eq_factor) -
-          (exe_total * eq_factor_final),
+        exe_diff = (exe_total * stage_eq_factor) -(exe_total * eq_factor_final),
         tax_code = lookup_tax_code(2019, pin)
       ),
     sb_pin_dt_actual %>%
@@ -557,6 +562,10 @@ sb_cntr_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
   sb_agency_dt <- lookup_agency(sb_pin_diff$year, sb_pin_diff$tax_code) %>%
     left_join(sb_pin_diff, by = c("year", "tax_code")) %>%
     left_join(eq_dt_stage, by = "year") %>%
+    group_by(agency_num, agency_name) %>%
+    mutate(eav_diff_total = sum(eav_diff_total),
+           exe_diff_total = sum(exe_diff_total)) %>%
+    ungroup() %>%
     mutate(
       agency_total_eav = round(
         (agency_total_eav / eq_factor_final) * stage_eq_factor
@@ -568,6 +577,7 @@ sb_cntr_all <- purrr::map_dfr(c("mailed", "certified", "board"), function(x) {
       -eav_diff_total, -exe_diff_total,
       -eq_factor_final, -stage_eq_factor
     ) %>%
+    as.data.table() %>%
     setkey(year, tax_code, agency_num)
 
   # Commercial PINs don't get appeals, so their EAVs only come from the


### PR DESCRIPTION
While reviewing possible reasons for [Appeals vignette agency totals issue #46 ](https://github.com/ccao-data/ptaxsim/issues/46), an error was identified in the way the appeals vignette adds pre-appeal EAV back into the base for taxing districts. Currently the code aggregates the EAV difference between stages at the tax code level, while it should aggregate up to the agency. This results in agencies that cover multiple tax codes to have their agency rates vary across tax codes, while agencies should have a uniform tax rate regardless of the tax code. 

This PR adjusts the code to ensure the EAV difference within each tax code is summed across all tax codes of an agency. This fix does help in aligning the summed amount taxed by agencies between stages, which was the issue identified in issue #46 (this flagged that taxes collected by Cook County in 2021 would be 16% higher in the mailed stage than the board stage, when they both should theoretically remain close to that agency's extension). With this adjustment, the entirety of taxes paid Cook County for the mailed and board stages vary by 3.8% rather than 16%. 