### PR TITLE
Remove unnecessary AWS auth when preparing DB on CI

### DIFF
--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -47,10 +47,11 @@ runs:
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        curl \
+        aws s3 cp \
           ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 \
-          --no-progress-meter \
-          --output ptaxsim.db.bz2
+          ptaxsim.db.bz2 \
+          --quiet \
+          --no-sign-request
       shell: bash
       working-directory: ${{ env.PTAXSIM_DB_DIR }}
 

--- a/.github/actions/prepare-ptaxsim/action.yaml
+++ b/.github/actions/prepare-ptaxsim/action.yaml
@@ -5,8 +5,6 @@ inputs:
     required: false
     description: S3 URI of PTAXSIM database versions
     default: "s3://ccao-data-public-us-east-1/ptaxsim"
-  ASSUMED_ROLE:
-    description: AWS role used for S3 actions
 outputs:
   PTAXSIM_DB_DIR:
     description: "PTAXSIM database directory on runner"
@@ -45,18 +43,14 @@ runs:
         key: ${{ format('{0}-{1}', env.PTAXSIM_VERSION, hashFiles('DESCRIPTION')) }}
         enableCrossOsArchive: true
 
-    - name: Configure AWS credentials
-      if: steps.cache_db.outputs.cache-hit != 'true'
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.ASSUMED_ROLE }}
-        aws-region: us-east-1
-
     - name: Fetch database file
       id: fetch_db
       if: steps.cache_db.outputs.cache-hit != 'true'
       run: |
-        aws s3 cp ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 ptaxsim.db.bz2 --quiet
+        curl \
+          ${{ inputs.PTAXSIM_DB_BASE_URI }}/ptaxsim-${{ env.PTAXSIM_VERSION }}.db.bz2 \
+          --no-progress-meter \
+          --output ptaxsim.db.bz2
       shell: bash
       working-directory: ${{ env.PTAXSIM_DB_DIR }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,11 +21,6 @@ jobs:
     env:
       R_KEEP_PKG_SOURCE: yes
 
-    # Required for OIDC access to S3
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,8 +44,6 @@ jobs:
       - name: Prepare PTAXSIM database
         id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
-        with:
-          ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Set PTAXSIM database path
         run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,11 +11,6 @@ jobs:
   build-pkgdown-site:
     runs-on: ubuntu-latest
 
-    # Required for OIDC access to S3
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,8 +32,6 @@ jobs:
       - name: Prepare PTAXSIM database
         id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
-        with:
-          ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Set PTAXSIM database path
         run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,11 +9,6 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
 
-    # Required for OIDC access to S3
-    permissions:
-      id-token: write
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,8 +27,6 @@ jobs:
       - name: Prepare PTAXSIM database
         id: prep_ptaxsim_db
         uses: ./.github/actions/prepare-ptaxsim
-        with:
-          ASSUMED_ROLE: ${{ secrets.AWS_IAM_ROLE_TO_ASSUME_ARN }}
 
       - name: Set PTAXSIM database path
         run: echo "PTAXSIM_DB_PATH=${{ steps.prep_ptaxsim_db.outputs.PTAXSIM_DB_DIR }}/ptaxsim.db" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes an issue that we noticed in the course of reviewing https://github.com/ccao-data/ptaxsim/pull/58: When external contributors open PRs against this repo, all CI checks that call the `prepare-ptaxsim` action will fail if the ptaxsim DB is not in the GitHub Actions cache. This happens because `prepare-ptaxsim` currently requires AWS authentication in order to download the ptaxsim DB from S3, and our AWS IAM policy for the role that runs CI checks is configured to disallow authentication from any repo other than `ccao-data/ptaxsim` (PRs from external contributors originate from their fork of the repo, not `ccao-data/ptaxsim`).

Since the ptaxsim DB in S3 is publicly accessible, we shouldn't need AWS auth to download it. Previously, it had required auth because we were neglecting to pass the `--no-sign-request` flag to `aws s3 cp`, which instructs the AWS CLI not to attempt to authenticate with S3 when issuing a copy request ([docs](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html)). This PR updates the `prepare-ptaxsim` action and the workflows that call it to use `--no-sign-request` and remove the now-unnecessary AWS auth step.

I'm issuing this PR from a personal fork of the repo to confirm that it will work for other forks.