### PR TITLE
Additional updates to agency ingest script

### DIFF
--- a/data-raw/agency/2024-agency-rate-report.xlsx
+++ b/data-raw/agency/2024-agency-rate-report.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd84c2b9fb22696bd4e827ef7dabe8245f35c3af089a965b31e65aead78d743f
-size 1164051
+oid sha256:1ec769b10e9f9922e5a5f3fa80c0fbaebdc538bf6eb59b26ffdc9b7cd0014795
+size 1132780

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -294,19 +294,8 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(all_of(c(
-        "cty_dupage_eav",
-        "cty_lake_eav",
-        "cty_will_eav",
-        "cty_kane_eav",
-        "cty_mchenry_eav",
-        "cty_dekalb_eav",
-        "cty_kankakee_eav",
-        "cty_kendall_eav",
-        "cty_grundy_eav",
-        "cty_lasalle_eav",
-        "cty_livingston_eav"
-      )))),
+      rowSums(across(collar_counties
+      )),
       cty_overlap_eav
     ),
     across(
@@ -600,19 +589,8 @@ agency_legacy_cw <-
   unique() %>%
   # Account for error in Clerk's report which lists Village of Skokie Library
   # Fund twice
-  filter(!(agency_num == "031170001" & agency_num_24 == "031170000")) %>%
-  # Correct error in Clerk's report which lists incorrect agency number for
-  # the TIF VIL OF OLYMPIA FIELDS-GOV HWY/VOLL
-  mutate(
-    across(
-      c(agency_num, agency_num_24),
-      ~ if_else(
-        agency_name_24 == "TIF VIL OF OLYMPIA FIELDS-GOV HWY/VOLL",
-        "030930502",
-        .x
-      )
-    )
-  )
+  filter(!(agency_num == "031170001" & agency_num_24 == "031170000"))
+
 
 agency_info <- agency_info %>%
   left_join(agency_legacy_cw, by = "agency_num") %>%

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -197,18 +197,18 @@ arrow::write_parquet(
 # Define collar county EAV fields
 collar_counties <-
   c(
-  "cty_dupage_eav",
-  "cty_lake_eav",
-  "cty_will_eav",
-  "cty_kane_eav",
-  "cty_mchenry_eav",
-  "cty_dekalb_eav",
-  "cty_kankakee_eav",
-  "cty_kendall_eav",
-  "cty_grundy_eav",
-  "cty_lasalle_eav",
-  "cty_livingston_eav"
-)
+    "cty_dupage_eav",
+    "cty_lake_eav",
+    "cty_will_eav",
+    "cty_kane_eav",
+    "cty_mchenry_eav",
+    "cty_dekalb_eav",
+    "cty_kankakee_eav",
+    "cty_kendall_eav",
+    "cty_grundy_eav",
+    "cty_lasalle_eav",
+    "cty_livingston_eav"
+  )
 
 # Load the overview of each agency file. This includes the agency name, total
 # EAV, final extension, and much more
@@ -294,17 +294,19 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(all_of(c("cty_dupage_eav",
-                              "cty_lake_eav",
-                              "cty_will_eav",
-                              "cty_kane_eav",
-                              "cty_mchenry_eav",
-                              "cty_dekalb_eav",
-                              "cty_kankakee_eav",
-                              "cty_kendall_eav",
-                              "cty_grundy_eav",
-                              "cty_lasalle_eav",
-                              "cty_livingston_eav")))),
+      rowSums(across(all_of(c(
+        "cty_dupage_eav",
+        "cty_lake_eav",
+        "cty_will_eav",
+        "cty_kane_eav",
+        "cty_mchenry_eav",
+        "cty_dekalb_eav",
+        "cty_kankakee_eav",
+        "cty_kendall_eav",
+        "cty_grundy_eav",
+        "cty_lasalle_eav",
+        "cty_livingston_eav"
+      )))),
       cty_overlap_eav
     ),
     across(

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -152,11 +152,19 @@ agency_fund <- map_dfr(file_names, function(file) {
 
 # agency_fund_info -------------------------------------------------------------
 
+# Create fund_type crosswalk
+fund_type_cw <- agency_fund %>%
+  filter(year < 2024) %>%
+  group_by(fund_type_num) %>%
+  summarise(fund_type_name = calc_mode(fund_name))
+
+
 # Breakout the fund names into their own table
 agency_fund_info <- agency_fund %>%
-  group_by(fund_type_num, fund_num) %>%
+  group_by(agency_num, fund_type_num, fund_num) %>%
   summarise(fund_name = calc_mode(fund_name)) %>%
   ungroup() %>%
+  left_join(fund_type_cw) %>%
   arrange(fund_num) %>%
   mutate(
     fund_name = str_trim(str_squish(fund_name)),
@@ -185,6 +193,22 @@ arrow::write_parquet(
 
 
 # agency -----------------------------------------------------------------------
+
+# Define collar county EAV fields
+collar_counties <-
+  c(
+  "cty_dupage_eav",
+  "cty_lake_eav",
+  "cty_will_eav",
+  "cty_kane_eav",
+  "cty_mchenry_eav",
+  "cty_dekalb_eav",
+  "cty_kankakee_eav",
+  "cty_kendall_eav",
+  "cty_grundy_eav",
+  "cty_lasalle_eav",
+  "cty_livingston_eav"
+)
 
 # Load the overview of each agency file. This includes the agency name, total
 # EAV, final extension, and much more
@@ -270,18 +294,7 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(starts_with(c(
-        "cty_dupage_eav",
-        "cty_lake_eav",
-        "cty_will_eav",
-        "cty_kane_eav",
-        "cty_mchenry_eav",
-        "cty_dekalb_eav",
-        "cty_kankakee_eav",
-        "cty_grundy_eav",
-        "cty_lasalle_eav",
-        "cty_livingston_eav"
-      )))),
+      rowSums(across(all_of(collar_counties))),
       cty_overlap_eav
     ),
     across(
@@ -320,7 +333,7 @@ agency <- map_dfr(file_names, function(file) {
       ~ as.double(.x)
     )
   ) %>%
-  select(-total_reduced_levy) %>%
+  select(-total_reduced_levy, -collar_counties) %>%
   relocate(total_ext, .after = everything())
 
 # Tax year 2013 is missing the total levy columns from its overview sheet, but

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -103,7 +103,7 @@ agency_fund <- map_dfr(file_names, function(file) {
     agency_num = str_pad(agency_num, 9, "left", "0"),
     fund_num = str_pad(fund_num, 3, "left", "0"),
     loss_pct = ifelse(
-      year == 2011 & agency_num == "030380104" & fund_num == "001",
+      year == 2011 & agency_num == "030380104" & fund_num == "001000",
       0,
       loss_pct
     ),
@@ -126,7 +126,7 @@ agency_fund <- map_dfr(file_names, function(file) {
     rate_ceiling = ifelse(final_rate == 0 & final_levy == 0, 0, rate_ceiling),
     ptell_reduced_levy = na_if(ptell_reduced_levy, 0),
     final_rate = ifelse(
-      agency_num == "050200000" & fund_num == "202" & year == 2006,
+      agency_num == "050200000" & fund_num == "202000" & year == 2006,
       0,
       final_rate
     )

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -336,7 +336,7 @@ agency <- map_dfr(file_names, function(file) {
       ~ as.double(.x)
     )
   ) %>%
-  select(-total_reduced_levy, -collar_counties) %>%
+  select(-total_reduced_levy, -all_of(collar_counties)) %>%
   relocate(total_ext, .after = everything())
 
 # Tax year 2013 is missing the total levy columns from its overview sheet, but

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -248,6 +248,9 @@ agency <- map_dfr(file_names, function(file) {
     rename_with(~"reduction_pct", any_of(c(
       "reduction_percent", "reduction_factor", "clerk_reduction_factor"
     ))) %>%
+    rename_with(~"total_non_cap_ext", any_of(c(
+      "total_non_cap_ext", "final_non_cap_ext", "total_non_cap_extension"
+    ))) %>%
     rename_with(~"total_ext", any_of(c(
       "total_ext", "final_ext",
       "grand_total_ext"
@@ -267,8 +270,8 @@ agency <- map_dfr(file_names, function(file) {
       agency_num = agency, agency_name, home_rule_ind,
       lim_numerator, lim_denominator, lim_rate, prior_eav, curr_new_prop,
       ends_with("_eav"), percent_burden,
-      reduction_pct,
       starts_with("grand_total_"),
+      reduction_pct, total_non_cap_ext,
       any_of("total_ext")
     ) %>%
     rename_with(~ paste0("cty_", .x), ends_with("_eav")) %>%
@@ -329,7 +332,7 @@ agency <- map_dfr(file_names, function(file) {
     across(
       c(
         lim_rate, pct_burden, total_prelim_rate, total_final_rate,
-        reduction_pct, total_ext
+        reduction_pct, total_non_cap_ext, total_ext
       ),
       ~ as.double(.x)
     )

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -297,8 +297,7 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(collar_counties
-      )),
+      rowSums(across(collar_counties)),
       cty_overlap_eav
     ),
     across(

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -294,7 +294,17 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(all_of(collar_counties))),
+      rowSums(across(all_of(c("cty_dupage_eav",
+                              "cty_lake_eav",
+                              "cty_will_eav",
+                              "cty_kane_eav",
+                              "cty_mchenry_eav",
+                              "cty_dekalb_eav",
+                              "cty_kankakee_eav",
+                              "cty_kendall_eav",
+                              "cty_grundy_eav",
+                              "cty_lasalle_eav",
+                              "cty_livingston_eav")))),
       cty_overlap_eav
     ),
     across(

--- a/data-raw/agency/agency.R
+++ b/data-raw/agency/agency.R
@@ -297,7 +297,7 @@ agency <- map_dfr(file_names, function(file) {
     home_rule_ind = home_rule_ind %in% c("Y", "HR", "No PTELL"),
     home_rule_ind = replace_na(home_rule_ind, FALSE),
     cty_overlap_eav = ifelse(year < "2024",
-      rowSums(across(collar_counties)),
+      rowSums(across(all_of(collar_counties))),
       cty_overlap_eav
     ),
     across(

--- a/data-raw/tax_code/2024-tax-code-agency-rate-file.xlsx
+++ b/data-raw/tax_code/2024-tax-code-agency-rate-file.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24d33d16fc774b4c23fbfeb271abba11576dcbb1b1a0ef50937c6dcff9e04e39
-size 3367116
+oid sha256:da8c364542da9ade722310d90871381a4184c95a7aae6e2d1c76680c5ba3567f
+size 3468524


### PR DESCRIPTION
This PR makes a few tweaks to the `agency.R` ingest script. After some consideration, we've opted to remove the individual collar county EAV fields (i.e. `dupage_cty_eav`) given these are no longer included as individual fields in the 2024 agency reports. Rather, they are summed to `overlap_eav`. This will resolve the issue that persists with the 2021 agency report in which two county EAV fields are mislabeled. 

The other change is revising the table `agency_fund_info`. This table will now include `agency_num`, given the discover that different agencies with the same `fund_num` have different fund names (mainly Bond Series funds). I also created a field `fund_type_name`, which pulls the standard name for a fund prior to 2024. This will allow a user to more easily analyze funds aggregated by their broader categories. 

@jeancochrane  I know this is a bit more involved than what we discussed, so let me know if you want to talk through or have any concerns with this approach!!