### PR TITLE
Add $0 bill output for PINs with an EAV less than $150

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -214,9 +214,9 @@ database and functions to handle these changes in the source data.
       PTAXSIM to analyze specific agencies over time so that you understand how
       to update your code.
 - **Corrected how the `tax_bill` function treats PINs with an EAV that is less
-  than $150, now defaulting the final tax output to zero. This aligns with the 
+  than $150, now defaulting the final tax output to zero**. This aligns with the 
   Treasurer's treatment of these PINs, so the tax bill calculation for these 
-  PINs will now match the what is shown on the final tax bill.**.
+  PINs will now match the what is shown on the final tax bill
   ([#91](https://github.com/ccao-data/ptaxsim/pull/91)).
     - **How this change affects you**: This improves the accuracy of the 
     `tax_bill` function to match what is displayed the Treasurer's tax bills.

--- a/NEWS.md
+++ b/NEWS.md
@@ -213,6 +213,14 @@ database and functions to handle these changes in the source data.
     - **How this change affects you**: You should read the vignette if you use
       PTAXSIM to analyze specific agencies over time so that you understand how
       to update your code.
+- **Corrected how the `tax_bill` function treats PINs with an EAV that is less
+  than $150, now defaulting the final tax output to zero. This aligns with the 
+  Treasurer's treatment of these PINs, so the tax bill calculation for these 
+  PINs will now match the what is shown on the final tax bill.**.
+  ([#91](https://github.com/ccao-data/ptaxsim/pull/91)).
+    - **How this change affects you**: This improves the accuracy of the 
+    `tax_bill` function to match what is displayed the Treasurer's tax bills.
+    This change has no impact on how to use the `tax_bill` function.
 
 ## Bug fixes
 

--- a/R/tax_bill.R
+++ b/R/tax_bill.R
@@ -242,6 +242,7 @@ tax_bill <- function(year_vec,
   dt[, tax_amt_pre_exe := round(eav * agency_tax_rate, 2)]
   dt[, tax_amt_post_exe := round(tax_amt_pre_exe - tax_amt_exe, 2)]
   dt[tax_amt_post_exe < 0, tax_amt_post_exe := 0]
+  dt[eav < 150, tax_amt_post_exe := 0]
   dt[, final_tax_to_tif := tax_amt_post_exe * tif_share]
 
   # add transit tifs

--- a/R/tax_bill.R
+++ b/R/tax_bill.R
@@ -242,7 +242,7 @@ tax_bill <- function(year_vec,
   dt[, tax_amt_pre_exe := round(eav * agency_tax_rate, 2)]
   dt[, tax_amt_post_exe := round(tax_amt_pre_exe - tax_amt_exe, 2)]
   dt[tax_amt_post_exe < 0, tax_amt_post_exe := 0]
-  dt[eav < 150, tax_amt_post_exe := 0]
+  dt[eav - exe_total < 150, tax_amt_post_exe := 0]
   dt[, final_tax_to_tif := tax_amt_post_exe * tif_share]
 
   # add transit tifs

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -425,9 +425,11 @@ test_that("PINs with EAV <= $150 have $0 tax bill", {
   AND av_board > 0
   "
     ) %>%
-    mutate(eav = av_board * eq_factor_final,
-           exe_total = rowSums(across(starts_with("exe_")))) %>%
-    filter( eav - exe_total < 150) %>%
+    mutate(
+      eav = av_board * eq_factor_final,
+      exe_total = rowSums(across(starts_with("exe_")))
+    ) %>%
+    filter(eav - exe_total < 150) %>%
     distinct(pin)
 
   eav_lt_150_bills <- tax_bill(2006:2024, eav_lt_150_pins$pin) %>%

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -412,4 +412,25 @@ test_that("Simplify FALSE / TRUE identical", {
   )
 })
 
+test_that("PINs with EAV <= $150 have $0 tax bill", {
+  eav_lt_150_pins <-
+    DBI::dbGetQuery(
+      ptaxsim_db_conn,
+      "
+  SELECT
+  pin, av_board, eq_factor_final, a.year
+  FROM pin a
+  LEFT JOIN eq_factor b on a.year = b.year
+  WHERE av_board < 1000
+  AND av_board > 0
+  ") %>%
+    mutate(eav = av_board * eq_factor_final) %>%
+    filter(eav < 150) %>%
+    distinct(pin)
+
+  eav_lt_150_bills <- tax_bill(2006:2024, eav_lt_150_pins$pin) %>%
+    filter(eav < 150)
+
+  expect_equal(sum(eav_lt_150_bills$final_tax), 0)})
+
 DBI::dbDisconnect(ptaxsim_db_conn)

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -425,12 +425,14 @@ test_that("PINs with EAV <= $150 have $0 tax bill", {
   AND av_board > 0
   "
     ) %>%
-    mutate(eav = av_board * eq_factor_final) %>%
-    filter(eav < 150) %>%
+    mutate(eav = av_board * eq_factor_final,
+           exe_total = rowSums(across(starts_with("exe_")))) %>%
+    filter( eav - exe_total < 150) %>%
     distinct(pin)
 
   eav_lt_150_bills <- tax_bill(2006:2024, eav_lt_150_pins$pin) %>%
-    filter(eav < 150)
+    mutate(exe_total = rowSums(across(starts_with("exe_")))) %>%
+    filter(eav - exe_total < 150)
 
   expect_equal(sum(eav_lt_150_bills$final_tax), 0)
 })

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -423,7 +423,8 @@ test_that("PINs with EAV <= $150 have $0 tax bill", {
   LEFT JOIN eq_factor b on a.year = b.year
   WHERE av_board < 1000
   AND av_board > 0
-  ") %>%
+  "
+    ) %>%
     mutate(eav = av_board * eq_factor_final) %>%
     filter(eav < 150) %>%
     distinct(pin)
@@ -431,6 +432,7 @@ test_that("PINs with EAV <= $150 have $0 tax bill", {
   eav_lt_150_bills <- tax_bill(2006:2024, eav_lt_150_pins$pin) %>%
     filter(eav < 150)
 
-  expect_equal(sum(eav_lt_150_bills$final_tax), 0)})
+  expect_equal(sum(eav_lt_150_bills$final_tax), 0)
+})
 
 DBI::dbDisconnect(ptaxsim_db_conn)


### PR DESCRIPTION
This PR adds an exception to the `tax_bill()` function, defaulting the tax bill amount to zero when a PIN's final EAV is less than $150, mirroring the Treasurer which does not send tax bills to PINs with an EAV that is less than $150 and ultimately records the bill as $0. This ensures alignment between the `final_tax` output of the `tax_bill()` function and the `tax_bill_total` field which mirrors the final bill amount from the Treasurer's data. 