### PR TITLE
Update testthat to Edition 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     snakecase,
     stringr,
     tabulapdf,
-    testthat,
+    testthat (>= 3.0.0),
     tidyr,
     units,
     usethis
@@ -68,3 +68,4 @@ Remotes:
     ropensci/tabulapdf
 Config/Requires_DB_Version: 2024.0.0
 Config/Wants_DB_Version: 2024.0.0
+Config/testthat/edition: 3

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -1,5 +1,3 @@
-context("test check_dt()")
-
 ##### TEST check_dt() #####
 
 library(data.table)
@@ -88,8 +86,6 @@ test_that("outputs fail if not keyed data.table", {
 })
 
 
-context("test check_db_conn()")
-
 ##### TEST check_db_conn() #####
 
 test_that("correct database path works as expected", {
@@ -113,8 +109,6 @@ test_that("missing tables throws error", {
   expect_error(check_db_conn(ptaxsim_db_conn_wrong), regexp = "missing")
 })
 
-
-context("test check_db_sync()")
 
 ##### TEST check_db_sync() #####
 

--- a/tests/testthat/test-lookup.R
+++ b/tests/testthat/test-lookup.R
@@ -1,5 +1,3 @@
-context("test lookup_vec()")
-
 ##### TEST lookup_vec() #####
 
 library(dplyr)
@@ -72,8 +70,6 @@ test_that("test that lookup values are correct compared to real bill data", {
 # Testing the lookups for functions that return data frames. These are harder to
 # test since their output returns complex structured data/objects
 
-context("test lookup_tif()")
-
 ##### TEST lookup_tif() #####
 
 test_that("lookup values/data are correct", {
@@ -125,8 +121,6 @@ test_that("bad/incorrect inputs throw errors", {
 })
 
 
-context("test lookup_pin()")
-
 ##### TEST lookup_pin() #####
 
 test_that("lookup values/data are correct", {
@@ -160,25 +154,26 @@ test_that("lookup values/data are correct", {
   )
 
   # Match all values in real data to lookup values
-  expect_equivalent(
-    lookup_pin(2018:max_year, sum_df$pin) %>%
-      mutate(
-        exe_vet_dis = (
-          exe_vet_dis_lt50 + exe_vet_dis_50_69 +
-            exe_vet_dis_ge70 + exe_vet_dis_100 +
-            exe_wwii
-        ),
-        across(starts_with("exe_"), ~ .x != 0)
-      ) %>%
-      select(year, pin, exe_homeowner:exe_disabled, exe_vet_dis) %>%
-      semi_join(sum_df, by = c("year", "pin")),
-    sum_df %>%
-      select(
-        year, pin, exe_homeowner:exe_disabled,
-        exe_vet_dis = exe_vet_disabled
-      ) %>%
-      as_tibble()
-  )
+expect_equal(
+  lookup_pin(2018:max_year, sum_df$pin) %>%
+    mutate(
+      exe_vet_dis = (
+        exe_vet_dis_lt50 + exe_vet_dis_50_69 +
+          exe_vet_dis_ge70 + exe_vet_dis_100 +
+          exe_wwii
+      ),
+      across(starts_with("exe_"), ~ .x != 0)
+    ) %>%
+    select(year, pin, exe_homeowner:exe_disabled, exe_vet_dis) %>%
+    semi_join(sum_df, by = c("year", "pin")),
+  sum_df %>%
+    select(
+      year, pin, exe_homeowner:exe_disabled,
+      exe_vet_dis = exe_vet_disabled
+    ) %>%
+    as_tibble(),
+  ignore_attr = TRUE
+)
 })
 
 test_that("function returns expect data type/structure", {
@@ -212,8 +207,6 @@ test_that("bad/incorrect inputs throw errors", {
   expect_error(lookup_pin(2019, pins[1], eq_version = 1))
 })
 
-
-context("test lookup_pin_tif()")
 
 ##### TEST lookup_pin_tif() #####
 
@@ -264,8 +257,6 @@ test_that("lookup_pin_tif handles multiple PINs", {
   expect_equal(nrow(result), 2)
 })
 
-
-context("test lookup_agency()")
 
 ##### TEST lookup_agency() #####
 
@@ -340,8 +331,6 @@ test_that("bad/incorrect inputs throw errors", {
   expect_error(lookup_agency(2019, 73105))
 })
 
-
-context("test lookup_pin10_geometry()")
 
 ##### TEST lookup_pin10_geometry() #####
 

--- a/tests/testthat/test-lookup.R
+++ b/tests/testthat/test-lookup.R
@@ -154,26 +154,26 @@ test_that("lookup values/data are correct", {
   )
 
   # Match all values in real data to lookup values
-expect_equal(
-  lookup_pin(2018:max_year, sum_df$pin) %>%
-    mutate(
-      exe_vet_dis = (
-        exe_vet_dis_lt50 + exe_vet_dis_50_69 +
-          exe_vet_dis_ge70 + exe_vet_dis_100 +
-          exe_wwii
-      ),
-      across(starts_with("exe_"), ~ .x != 0)
-    ) %>%
-    select(year, pin, exe_homeowner:exe_disabled, exe_vet_dis) %>%
-    semi_join(sum_df, by = c("year", "pin")),
-  sum_df %>%
-    select(
-      year, pin, exe_homeowner:exe_disabled,
-      exe_vet_dis = exe_vet_disabled
-    ) %>%
-    as_tibble(),
-  ignore_attr = TRUE
-)
+  expect_equal(
+    lookup_pin(2018:max_year, sum_df$pin) %>%
+      mutate(
+        exe_vet_dis = (
+          exe_vet_dis_lt50 + exe_vet_dis_50_69 +
+            exe_vet_dis_ge70 + exe_vet_dis_100 +
+            exe_wwii
+        ),
+        across(starts_with("exe_"), ~ .x != 0)
+      ) %>%
+      select(year, pin, exe_homeowner:exe_disabled, exe_vet_dis) %>%
+      semi_join(sum_df, by = c("year", "pin")),
+    sum_df %>%
+      select(
+        year, pin, exe_homeowner:exe_disabled,
+        exe_vet_dis = exe_vet_disabled
+      ) %>%
+      as_tibble(),
+    ignore_attr = TRUE
+  )
 })
 
 test_that("function returns expect data type/structure", {

--- a/tests/testthat/test-sample_tax_bills_summary.R
+++ b/tests/testthat/test-sample_tax_bills_summary.R
@@ -1,5 +1,3 @@
-context("Test sample_tax_bills_summary")
-
 ##### TEST sample_tax_bills_summary #####
 
 library(dplyr)

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -1,5 +1,3 @@
-context("test tax_bill()")
-
 ##### TEST tax_bill() #####
 
 library(data.table)
@@ -101,7 +99,7 @@ test_that("function returns expected data type/structure", {
 
 test_that("returned amount/output correct for single PIN", {
   # District level tax amounts
-  expect_equivalent(
+  expect_equal(
     tax_bill(2018, pins[3], simplify = TRUE) %>%
       select(year, pin, agency_num, final_tax) %>%
       arrange(agency_num) %>%
@@ -111,7 +109,8 @@ test_that("returned amount/output correct for single PIN", {
       select(year, pin, agency_num, final_tax) %>%
       arrange(agency_num) %>%
       as_tibble(),
-    tolerance = 0.005
+    tolerance = 0.005,
+    ignore_attr = TRUE
   )
 })
 
@@ -396,13 +395,14 @@ test_that("Simplify FALSE / TRUE identical", {
   simp_bills <- tax_bill(2023, rpm_tif_pins, simplify = TRUE)
   not_simp_bills <- tax_bill(2023, rpm_tif_pins, simplify = FALSE)
 
-  expect_equivalent(
-    simp_bills %>% summarize(total_tax = sum(final_tax)),
-    not_simp_bills %>%
-      summarize(total_tax = sum(final_tax_to_tif +
-        final_tax_to_dist - transit_tif_to_dist)),
-    tolerance = 0.005
-  )
+expect_equal(
+  simp_bills %>% summarize(total_tax = sum(final_tax)),
+  not_simp_bills %>%
+    summarize(total_tax = sum(final_tax_to_tif +
+      final_tax_to_dist - transit_tif_to_dist)),
+  tolerance = 0.005,
+  ignore_attr = TRUE
+)
 })
 
 test_that("PINs with EAV <= $150 have $0 tax bill", {

--- a/tests/testthat/test-tax_bill.R
+++ b/tests/testthat/test-tax_bill.R
@@ -395,14 +395,14 @@ test_that("Simplify FALSE / TRUE identical", {
   simp_bills <- tax_bill(2023, rpm_tif_pins, simplify = TRUE)
   not_simp_bills <- tax_bill(2023, rpm_tif_pins, simplify = FALSE)
 
-expect_equal(
-  simp_bills %>% summarize(total_tax = sum(final_tax)),
-  not_simp_bills %>%
-    summarize(total_tax = sum(final_tax_to_tif +
-      final_tax_to_dist - transit_tif_to_dist)),
-  tolerance = 0.005,
-  ignore_attr = TRUE
-)
+  expect_equal(
+    simp_bills %>% summarize(total_tax = sum(final_tax)),
+    not_simp_bills %>%
+      summarize(total_tax = sum(final_tax_to_tif +
+        final_tax_to_dist - transit_tif_to_dist)),
+    tolerance = 0.005,
+    ignore_attr = TRUE
+  )
 })
 
 test_that("PINs with EAV <= $150 have $0 tax bill", {


### PR DESCRIPTION
PR to upgrade testthat to a minimum version of 3 and follow-up to https://github.com/ccao-data/ccao/pull/51.

In unrelated notes, the tax rates vignette is randomly failing as seen [here](https://github.com/ccao-data/ptaxsim/actions/runs/25695680596/job/75443163338).