### PR TITLE
Retry Socrata API requests in case of failure in vignettes

### DIFF
--- a/vignettes/reassessment.Rmd
+++ b/vignettes/reassessment.Rmd
@@ -249,7 +249,10 @@ To do so, we construct a query using Socrata’s API. This will let us get only 
 ```{r}
 base_url <- "https://datacatalog.cookcountyil.gov/resource/tx2p-k2g9.json"
 
-cw_pins <- GET(
+# Retry request in case of failure, since the Socrata API sometimes closes
+# connections unexpectedly
+cw_pins <- RETRY(
+  "GET",
   base_url,
   query = list(
     year = 2018,

--- a/vignettes/tax_rates.Rmd
+++ b/vignettes/tax_rates.Rmd
@@ -75,7 +75,10 @@ north_tri_tax_codes <- data.frame(
 )
 
 for (year in 2012:2023) {
-  response <- GET(
+  # Retry request in case of failure, since the Socrata API sometimes closes
+  # connections unexpectedly
+  response <- RETRY(
+    "GET",
     base_url,
     query = list(
       year = year,


### PR DESCRIPTION
Damon noticed that the tax rate vignette sometimes fails to render because the Socrata API closes the connection during a query. [See these logs for an example](https://github.com/ccao-data/ptaxsim/actions/runs/25695860820/job/75443785563):

```
! Failed to render 'vignettes/tax_rates.Rmd'.
✖ Quitting from tax_rates.Rmd:65-94 [unnamed-chunk-3]
✖ Warning message:
✖ call dbDisconnect() when finished working with a connection
Caused by error:
! Failure when receiving data from the peer [datacatalog.cookcountyil.gov]:
Recv failure: Connection reset by peer
Backtrace:
    ▆
 1. ├─httr::GET(...)
 2. │ └─httr:::request_perform(req, hu$handle$handle)
 3. │   ├─httr:::request_fetch(req$output, req$url, handle)
 4. │   └─httr:::request_fetch.write_memory(req$output, req$url, handle)
 5. │     └─curl::curl_fetch_memory(url, handle = handle)
 6. └─curl:::raise_libcurl_error(...)
Execution halted
```

Our Socrata API work in `data-architecture` has revealed that closed connections are common when working with the Socrata API, so this PR tweaks our vignettes to use the [`RETRY()` httr function](https://httr.r-lib.org/reference/RETRY.html) to retry requests to Socrata in case of closed connections.

There's no definitive way to test that this change resolves the sporadic errors, since they are non-deterministic and so not reproducible. But I don't think this change will hurt, and we can re-evaluate it later if we notice builds continuing to fail.