### PR TITLE
Enable-llms.txt-for-docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     odbc,
     openxlsx,
     pdftools,
-    pkgdown,
+    pkgdown (>= 2.2.0),
     prettymapr,
     purrr,
     readr,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,6 @@
 destination: public
 url: https://github.com/ccao-data/ptaxsim
+llm-docs: true
 template:
   bootstrap: 5
 


### PR DESCRIPTION
I'll let you decide if you want to standardize this. It appears as though the docs are already uploaded since we made more recent updates in this repository. Presumably here.
`
template:
  bootstrap: 5
`
https://ccao-data.github.io/ptaxsim/llms.txt

Companion issue to https://github.com/ccao-data/assessr/pull/26 and https://github.com/ccao-data/lightsnip/pull/24 for 
https://github.com/ccao-data/assessr/issues/25

[llms.txt](https://github.com/user-attachments/files/28526384/llms.txt)
